### PR TITLE
섹션 7. 주문 도메인 개발

### DIFF
--- a/jpashop/src/main/java/jpabook/jpashop/domain/Order.java
+++ b/jpashop/src/main/java/jpabook/jpashop/domain/Order.java
@@ -1,7 +1,9 @@
 package jpabook.jpashop.domain;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
@@ -11,6 +13,7 @@ import java.util.List;
 @Entity
 @Table(name = "orders")
 @Getter @Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Order {
 
     @Id @GeneratedValue
@@ -52,4 +55,46 @@ public class Order {
         delivery.setOrder(this);
     }
 
+    //==생성 메소드==//
+    public static Order createOrder(Member member, Delivery delivery, OrderItem... orderItems) {
+        Order order = new Order();
+        order.setMember(member);
+        order.setDelivery(delivery);
+        for (OrderItem orderItem : orderItems) {
+            order.addOrderItem(orderItem);
+        }
+        order.setStatus(OrderStatus.ORDER);
+        order.setOrderDate(LocalDateTime.now());
+        return order;
+    }
+
+    //==비즈니스 로직==//
+    /**
+     * 주문 취소
+     */
+    public void cancel() {
+        if(delivery.getStatus() == DeliveryStatus.COMP) {
+            throw new IllegalStateException("이미 배송완료된 상품은 취소가 불가능합니다.");
+        }
+
+        this.setStatus(OrderStatus.CANCEL);
+        for(OrderItem orderItem : orderItems) {
+            orderItem.cancel();
+        }
+    }
+
+    //==조회 로직==//
+    /**
+     * 전체 주문 가격 조회
+     */
+    public int getTotalPrice() {
+//        int totalPrice = 0;
+//        for (OrderItem orderItem : orderItems) {
+//            totalPrice += orderItem.getTotalPrice();
+//        }
+//        return totalPrice;
+        return orderItems.stream()
+                .mapToInt(OrderItem::getTotalPrice)
+                .sum();
+    }
 }

--- a/jpashop/src/main/java/jpabook/jpashop/domain/OrderItem.java
+++ b/jpashop/src/main/java/jpabook/jpashop/domain/OrderItem.java
@@ -2,11 +2,14 @@ package jpabook.jpashop.domain;
 
 import jakarta.persistence.*;
 import jpabook.jpashop.domain.item.Item;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
 @Getter @Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class OrderItem {
 
     @Id @GeneratedValue
@@ -23,4 +26,30 @@ public class OrderItem {
 
     private int orderPrice; //주문 가격
     private int count;  //주문 수량
+
+//    protected OrderItem() {} //Lombok을 사용
+
+    //==생성 메소드==//
+    public static OrderItem createOrderItem(Item item, int orderPrice, int count) {
+        OrderItem orderItem = new OrderItem();
+        orderItem.setItem(item);
+        orderItem.setOrderPrice(orderPrice);
+        orderItem.setCount(count);
+
+        item.removeStock(count);
+        return orderItem;
+    }
+
+    //==비즈니스 로직==//
+    public void cancel() {
+        getItem().addStock(count);
+    }
+
+    //==조회 로직==//
+    /**
+     * 주문상품 전체 가격 조회
+     */
+    public int getTotalPrice() {
+        return getOrderPrice() * getCount();
+    }
 }

--- a/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepository.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepository.java
@@ -1,0 +1,25 @@
+package jpabook.jpashop.repository;
+
+import jakarta.persistence.EntityManager;
+import jpabook.jpashop.domain.Order;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderRepository {
+
+    private final EntityManager em;
+
+    public void save(Order order) {
+        em.persist(order);
+    }
+
+    public Order findOne(Long id) {
+        return em.find(Order.class, id);
+    }
+
+//    public List<Order> findAll(OrderSearch orderSearch)
+}

--- a/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepository.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepository.java
@@ -1,10 +1,14 @@
 package jpabook.jpashop.repository;
 
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
+import jakarta.persistence.criteria.*;
 import jpabook.jpashop.domain.Order;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Repository
@@ -21,5 +25,70 @@ public class OrderRepository {
         return em.find(Order.class, id);
     }
 
-//    public List<Order> findAll(OrderSearch orderSearch)
+    public List<Order> findAllByString(OrderSearch orderSearch) {
+
+        //language=JPAQL
+        String jpql = "select o From Order o join o.member m";
+        boolean isFirstCondition = true;
+        //주문 상태 검색
+        if (orderSearch.getOrderStatus() != null) {
+            if (isFirstCondition) {
+                jpql += " where";
+                isFirstCondition = false;
+            } else {
+                jpql += " and";
+            }
+            jpql += " o.status = :status";
+        }
+        //회원 이름 검색
+        if (StringUtils.hasText(orderSearch.getMemberName())) {
+            if (isFirstCondition) {
+                jpql += " where";
+                isFirstCondition = false;
+            } else {
+                jpql += " and";
+            }
+            jpql += " m.name like :name";
+        }
+        TypedQuery<Order> query = em.createQuery(jpql, Order.class)
+                .setMaxResults(1000); //최대 1000건
+        if (orderSearch.getOrderStatus() != null) {
+            query = query.setParameter("status", orderSearch.getOrderStatus());
+        }
+        if (StringUtils.hasText(orderSearch.getMemberName())) {
+            query = query.setParameter("name", orderSearch.getMemberName());
+        }
+        return query.getResultList();
+    }
+
+    /**
+     * JPA Criteria
+     */
+    public List<Order> findAllByCriteria(OrderSearch orderSearch) {
+        CriteriaBuilder cb = em.getCriteriaBuilder();
+        CriteriaQuery<Order> cq = cb.createQuery(Order.class);
+        Root<Order> o = cq.from(Order.class);
+        Join<Object, Object> m = o.join("member", JoinType.INNER);
+
+        List<Predicate> criteria = new ArrayList<>();
+
+        //주문 상태 검색
+        if (orderSearch.getOrderStatus() != null) {
+            Predicate status = cb.equal(o.get("status"), orderSearch.getOrderStatus());
+            criteria.add(status);
+        }
+
+        //회원 이름 검색
+        if (orderSearch.getMemberName() != null) {
+            Predicate name = cb.like(m.<String>get("name"), "%" + orderSearch.getMemberName() + "%");
+            criteria.add(name);
+        }
+
+        cq.where(cb.and(criteria.toArray(new Predicate[criteria.size()])));
+        TypedQuery<Order> query = em.createQuery(cq).setMaxResults(1000);
+
+        return query.getResultList();
+    }
+
+
 }

--- a/jpashop/src/main/java/jpabook/jpashop/repository/OrderSearch.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/OrderSearch.java
@@ -1,0 +1,13 @@
+package jpabook.jpashop.repository;
+
+import jpabook.jpashop.domain.OrderStatus;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class OrderSearch {
+
+    private String memberName;
+    private OrderStatus orderStatus;
+
+}

--- a/jpashop/src/main/java/jpabook/jpashop/service/OrderService.java
+++ b/jpashop/src/main/java/jpabook/jpashop/service/OrderService.java
@@ -12,8 +12,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)

--- a/jpashop/src/main/java/jpabook/jpashop/service/OrderService.java
+++ b/jpashop/src/main/java/jpabook/jpashop/service/OrderService.java
@@ -1,0 +1,72 @@
+package jpabook.jpashop.service;
+
+import jpabook.jpashop.domain.Delivery;
+import jpabook.jpashop.domain.Member;
+import jpabook.jpashop.domain.Order;
+import jpabook.jpashop.domain.OrderItem;
+import jpabook.jpashop.domain.item.Item;
+import jpabook.jpashop.repository.ItemRepository;
+import jpabook.jpashop.repository.MemberRepository;
+import jpabook.jpashop.repository.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+    private final MemberRepository memberRepository;
+    private final ItemRepository itemRepository;
+
+    /**
+     *주문
+     */
+    @Transactional
+    public Long order(Long memberId, Long itemId, int count){
+
+        //엔티티 조회
+        Member member = memberRepository.findOne(memberId);
+        Item item = itemRepository.findOne(itemId);
+
+        //배송정보 조회
+        Delivery delivery = new Delivery();
+        delivery.setAddress(member.getAddress());
+
+        //주문상품 생성
+        OrderItem orderItem = OrderItem.createOrderItem(item, item.getPrice(), count);
+        // OrderItem엔티티에서 생성자를 protected로 설정하여 createOrderItem()을 제외한 다른 방식의 생성을 막음. JPA를 쓰면서 protected 접근 지정자는 그것을 사용하지 말라는 의미
+        // OrderItem orderItem1 = new OrderItem();
+
+        //주문 생성
+        Order order = Order.createOrder(member, delivery, orderItem);
+
+        //주문 저장
+        orderRepository.save(order);    //cascade 옵션 덕분에 order만 저장, delivery와 orderItem은 order에서만 참조하기 때문에 cascade 설정을 했다. 다른 곳에서도 중요하게 사용한다면 따로 persist를 하는 것이 좋다.
+
+        return order.getId();
+    }
+
+    /**
+     * 주문 취소
+     */
+    @Transactional
+    public void cancelOrder(Long orderId) {
+        //주문 엔티티 조회
+        Order order = orderRepository.findOne(orderId);
+        //주문 취소
+        order.cancel();
+    }
+
+    /**
+     * 검색
+     */
+//    public List<Order> findOrders(OrderSearch orderSearch) {
+//        return orderRepository.findAll(orderSearch);
+//    }
+
+}

--- a/jpashop/src/test/java/jpabook/jpashop/service/OrderServiceTest.java
+++ b/jpashop/src/test/java/jpabook/jpashop/service/OrderServiceTest.java
@@ -1,0 +1,103 @@
+package jpabook.jpashop.service;
+
+import jakarta.persistence.EntityManager;
+import jpabook.jpashop.domain.Address;
+import jpabook.jpashop.domain.Member;
+import jpabook.jpashop.domain.Order;
+import jpabook.jpashop.domain.OrderStatus;
+import jpabook.jpashop.domain.item.Book;
+import jpabook.jpashop.exception.NotEnoughStockException;
+import jpabook.jpashop.repository.OrderRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class OrderServiceTest {
+
+    @Autowired
+    EntityManager em;
+    @Autowired
+    OrderService orderService;
+    @Autowired
+    OrderRepository orderRepository;
+
+    @Test
+    public void 상품주문() throws Exception {
+        //given
+        Member member = createMember();
+
+        Book book = createBook("시골 JPA", 10000, 10);
+
+        int orderCount = 2;
+
+        //when
+        Long orderId = orderService.order(member.getId(), book.getId(), orderCount);
+
+        //then
+        Order getOrder = orderRepository.findOne(orderId);
+
+        assertEquals(OrderStatus.ORDER, getOrder.getStatus(), "상품 주문시 상태는 ORDER");
+        assertEquals(1, getOrder.getOrderItems().size(), "주문한 상품 종류 수가 정확해야 한다.");
+        assertEquals(book.getPrice() * orderCount, getOrder.getTotalPrice(), "주문 가격은 가격 * 수량이다.");
+        assertEquals(8, book.getStockQuantity(), "주문 수량만큼 재고가 줄어야 한다.");
+
+    }
+
+    @Test
+    public void 상품주문_재고수량초과() throws Exception {
+
+        //given
+        Member member = createMember();
+        Book book = createBook("시골 JPA", 10000, 10);
+
+        int orderCount = 11;
+
+        //when
+        assertThrows(NotEnoughStockException.class, () -> orderService.order(member.getId(), book.getId(), orderCount));
+
+        //then
+
+     }
+
+    @Test
+    public void 주문취소() throws Exception {
+        //given
+        Member member = createMember();
+        Book book = createBook("시골 JPA", 10000, 10);
+
+        int orderCount = 2;
+        Long orderId = orderService.order(member.getId(), book.getId(), orderCount);
+
+        //when
+        orderService.cancelOrder(orderId);
+
+        //then
+        Order getOrder = orderRepository.findOne(orderId);
+
+        assertEquals(OrderStatus.CANCEL, getOrder.getStatus(), "주문 취소시 상태는 CANCEL이다.");
+        assertEquals(10, book.getStockQuantity(), "주문이 취소된 상품은 그만큼 재고가 증가해야한다.");
+
+     }
+
+    private Book createBook(String name, int price, int stockQuantity) {
+        Book book = new Book();
+        book.setName(name);
+        book.setPrice(price);
+        book.setStockQuantity(stockQuantity);
+        em.persist(book);
+        return book;
+    }
+
+    private Member createMember() {
+        Member member = new Member();
+        member.setName("회원1");
+        member.setAddress(new Address("서울", "강가", "123-123"));
+        em.persist(member);
+        return member;
+    }
+}


### PR DESCRIPTION
예제의 핵심 기능인 주문 도메인 개발
1. order 생성 (delivery와 orderItem의 cascade 설정, orderItem의 생성 방식 단일화)
2. 주문 취소(order의 상태를 CANCEL로 변경, 주문 수량만큼 재고 증가)
3. 주문 검색(order의 상태와 member의 이름으로 검색) : 검색 방식에 따라 쿼리가 변경된다 -> 동적 쿼리
- 동적 쿼리(JPQL을 조건에 따라 조립하는 String 방식, JPA Criteria를 사용하는 방식)
-> 실무에서 사용하기 너무 복잡하다. Querydsl을 사용하는 것을 권장